### PR TITLE
Server starts immediately and we check if the arm is initialized in the CB

### DIFF
--- a/wpi_jaco_wrapper/include/wpi_jaco_wrapper/jaco_arm_trajectory_node.h
+++ b/wpi_jaco_wrapper/include/wpi_jaco_wrapper/jaco_arm_trajectory_node.h
@@ -244,7 +244,7 @@ private:
 
   bool eStopEnabled;
 
-  bool arm_intialized_;
+  bool arm_initialized;
 
   // Parameters
   std::string   arm_name_;

--- a/wpi_jaco_wrapper/include/wpi_jaco_wrapper/jaco_arm_trajectory_node.h
+++ b/wpi_jaco_wrapper/include/wpi_jaco_wrapper/jaco_arm_trajectory_node.h
@@ -244,6 +244,8 @@ private:
 
   bool eStopEnabled;
 
+  bool arm_intialized_;
+
   // Parameters
   std::string   arm_name_;
   double        finger_scale_;

--- a/wpi_jaco_wrapper/src/jaco_arm_trajectory_node.cpp
+++ b/wpi_jaco_wrapper/src/jaco_arm_trajectory_node.cpp
@@ -5,7 +5,7 @@ using namespace std;
 namespace jaco
 {
 JacoArmTrajectoryController::JacoArmTrajectoryController(ros::NodeHandle nh, ros::NodeHandle pnh)
-  : arm_intialized_ (false)
+  : arm_initialized (false)
 {
   loadParameters(nh);
 
@@ -97,7 +97,7 @@ JacoArmTrajectoryController::JacoArmTrajectoryController(ros::NodeHandle nh, ros
   msg.data = true;
   armHomedPublisher.publish(msg);
 
-  arm_intialized_ = true;
+  arm_initialized = true;
 }
 
 JacoArmTrajectoryController::~JacoArmTrajectoryController()
@@ -204,7 +204,7 @@ static inline double nearest_equivalent(double desired, double current)
 
 void JacoArmTrajectoryController::execute_trajectory(const control_msgs::FollowJointTrajectoryGoalConstPtr &goal)
 {
-  if ( not arm_intialized_ )
+  if ( not arm_initialized )
   {
     return; // The arm is not fully initialized yet
   }


### PR DESCRIPTION
When we start the arm and MoveIt! together, MoveIt sometimes complains that the trajectory controller is not connected.

This messages can be seen in lines 81 and 82 of the following source:
http://docs.ros.org/indigo/api/moveit_simple_controller_manager/html/action__based__controller__handle_8h_source.html

It is caused by the trajectory controller server which is not yet started in the driver. This can be caused when starting the API and moving the arm to the home position takes longer than 15 seconds. I have solved it by starting the server immediately, but having the callback function return immediately when the arm has not been initialized yet.